### PR TITLE
Add scrolling mechanism to autocomplete and fix UI bugs

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,13 +1,18 @@
 package seedu.address.ui;
 
+import java.awt.Dimension;
+import java.awt.Toolkit;
 import java.util.HashMap;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.geometry.Bounds;
 import javafx.geometry.Side;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
@@ -19,9 +24,11 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * The UI component that is responsible for receiving user command inputs.
  */
 public class CommandBox extends UiPart<Region> {
-
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
+    private static final int BORDER_SIZE = 10;
+    private static final int ITEM_SIZE = 30;
+    private static final double ITEM_PADDING = 1.5;
 
     private final CommandExecutor commandExecutor;
     private final AutocompleteParser autocompleteParser;
@@ -67,9 +74,34 @@ public class CommandBox extends UiPart<Region> {
                 autoComplete.hide();
             });
             autoComplete.getItems().add(item);
-        }
 
-        autoComplete.show(commandTextField, Side.BOTTOM, 0, 0);
+            autoComplete.setMaxHeight(150);
+            autoComplete.setMaxWidth(400);
+            autoComplete.setAutoFix(false);
+
+            autoComplete.show(commandTextField, Side.BOTTOM, 0, 0);
+
+            // To solve weird JavaFX behavior where scrolling position is not updated after items have changed.
+            autoComplete.getSkin().getNode().requestFocus();
+            commandTextField.fireEvent(new KeyEvent(
+                    KeyEvent.KEY_PRESSED, "", "",
+                    KeyCode.DOWN, false, false, false, false));
+        }
+        Bounds boundsInScreen = commandTextField.localToScreen(commandTextField.getBoundsInLocal());
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        double height = screenSize.getHeight();
+        double autocompleteHeight = Math.min(suggestions.size(), 5) * ITEM_SIZE
+                + BORDER_SIZE
+                - Math.min(suggestions.size() - 1, 5) * ITEM_PADDING;
+
+        // Position suggestion box above text field if there is insufficient space below the text box
+        if (height - boundsInScreen.getMaxY() < autocompleteHeight) {
+            autoComplete.show(commandTextField, Side.BOTTOM, 0, -autocompleteHeight - commandTextField.getHeight());
+            autoComplete.setOpacity(0.8);
+        } else {
+            autoComplete.show(commandTextField, Side.BOTTOM, 0, 0);
+            autoComplete.setOpacity(1);
+        }
     }
 
 

--- a/src/main/java/seedu/address/ui/MaxSizedContextMenu.java
+++ b/src/main/java/seedu/address/ui/MaxSizedContextMenu.java
@@ -1,0 +1,36 @@
+package seedu.address.ui;
+
+import javafx.scene.Node;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Menu;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
+
+/**
+ * Modified context menu component that has scrolling mechanism if max height is exceeded
+ */
+public class MaxSizedContextMenu extends ContextMenu {
+    public static final int CONTEXT_MENU_MAX_HEIGHT = 150;
+    public static final int CONTEXT_MENU_MAX_WIDTH = 400;
+
+    /**
+     * Constructor for max sized context menu
+     */
+    public MaxSizedContextMenu() {
+        addEventHandler(Menu.ON_SHOWING, e -> {
+            Node content = getSkin().getNode();
+            if (content instanceof Region regionContent) {
+                regionContent.setMaxHeight(CONTEXT_MENU_MAX_HEIGHT);
+                regionContent.setMaxWidth(CONTEXT_MENU_MAX_WIDTH);
+
+                // To solve weird JavaFX behavior where scrolling position is not updated after items have
+                // changed.
+                content.requestFocus();
+                this.fireEvent(new KeyEvent(
+                        KeyEvent.KEY_PRESSED, "", "",
+                        KeyCode.UP, false, false, false, false));
+            }
+        });
+    }
+}

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -2,12 +2,12 @@
 
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.control.ContextMenu?>
+<?import seedu.address.ui.MaxSizedContextMenu?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here...">
     <contextMenu>
-      <ContextMenu fx:id="autoComplete" maxWidth="340" />
+      <MaxSizedContextMenu fx:id="autoComplete" maxWidth="400" maxHeight="150" />
     </contextMenu>
   </TextField>
 </StackPane>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -396,3 +396,8 @@
     -fx-font-size: 20px;
     -fx-font-weight: bold;
 }
+
+#autoComplete {
+    -fx-background-color: derive(#1d1d1d, 35%);
+     -fx-border-color: #27272a;
+}


### PR DESCRIPTION
Changes

- Suggestions list now has a max height and width and is scrollable. Closes #121 
- When the program detects that there is insufficient space for the suggestions window under the command box, the suggestions list will be moved above it, and its opacity will be reduced to make sure that the chat bot messages are still readable. Closes #122 