### PR TITLE
Improve functionality of filter phone number

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * Helper functions for handling strings.
@@ -36,6 +37,38 @@ public class StringUtil {
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Returns true if the {@code phoneNumber} contains the {@code number}.
+     *   It requires at least one number to match the phoneNumber.
+     *   <br>examples:<pre>
+     *       containsNumber("123456", "123") == true
+     *       containsNumber("123456", "789") == false
+     *       containsNumber("123456", "124") == false
+     *       </pre>
+     * @param phoneNumber cannot be null, must be a single number
+     * @param number cannot be null, cannot be empty, must be a single number
+     */
+    public static boolean containsNumber(String phoneNumber, String number) {
+        requireNonNull(phoneNumber);
+        requireNonNull(number);
+
+        String preppedNumber = number.trim();
+        checkArgument(!preppedNumber.isEmpty(), "Number parameter cannot be empty");
+
+        String preppedPhoneNumber = phoneNumber.trim();
+        if (preppedPhoneNumber.isEmpty()) {
+            return false;
+        }
+
+        //phone number should not have any space
+        checkArgument(preppedNumber.split("\\s+").length == 1, "Number parameter should be a single word");
+        checkArgument(phoneNumber.split("\\s+").length == 1, "phoneNumber parameter should be a single word");
+
+        Pattern pattern = Pattern.compile("^\\d+$");
+
+        return pattern.matcher(phoneNumber).matches() && phoneNumber.contains(number);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/FilterPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterPredicate.java
@@ -66,7 +66,7 @@ public class FilterPredicate implements Predicate<Person> {
      */
     private boolean filterPhone(Person person) {
         return filterPersonDescriptor.getPhone()
-                .map(phone -> StringUtil.containsWordIgnoreCase(person.getPhone().value, phone.value))
+                .map(phone -> StringUtil.containsNumber(person.getPhone().value, phone.value))
                 .orElse(true);
     }
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -140,4 +140,47 @@ public class StringUtilTest {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
     }
 
+    @Test
+    public void containsNumber_validInput_correctResult() {
+        // Empty phoneNumber
+        assertFalse(StringUtil.containsNumber("", "123"));
+        assertFalse(StringUtil.containsNumber("    ", "123"));
+
+        // Matches a partial number only
+        assertTrue(StringUtil.containsNumber("12345678", "12"));
+        assertTrue(StringUtil.containsNumber("12345678", "45678"));
+
+        // Matches full number
+        assertTrue(StringUtil.containsNumber("12345678", "12345678"));
+
+        // Does not match partial number
+        assertFalse(StringUtil.containsNumber("12345678", "13"));
+        assertFalse(StringUtil.containsNumber("12345678", "123456789"));
+        assertFalse(StringUtil.containsNumber("12345678", "12347678"));
+    }
+
+    @Test
+    public void containsNumber_nullWord_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsNumber("12345678", null));
+    }
+
+    @Test
+    public void containsNumber_emptyNumber_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Number parameter cannot be empty", ()
+                -> StringUtil.containsNumber("12345678", "  "));
+    }
+
+    @Test
+    public void containsNumbers_multipleNumbers_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Number parameter should be a single word", ()
+                -> StringUtil.containsNumber("12345678", "12 34"));
+
+        assertThrows(IllegalArgumentException.class, "phoneNumber parameter should be a single word", ()
+                -> StringUtil.containsNumber("1234 5678", "1234"));
+    }
+
+    @Test
+    public void containsNumbers_nullPhoneNumber_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsNumber(null, "123"));
+    }
 }


### PR DESCRIPTION
The Filter command for the phone number parameter to filter partial phone number is supported.
eg. `filter p/123` will return a person list which contains 123 in the persons' phone number.