### PR TITLE
Fix Filter User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,16 +131,20 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li` _(search by multiple parameters)_ <br> 
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
-### Filter persons : `filter`
+### Filter persons
 
-Filters persons who meet all specified conditions.
+Filter persons who meet all specified conditions.
 
 Format: `filter [n/name] [p/phone] [g/gender] [t/tag]... [m/module]...`
 * The filter is case-insensitive. eg `hans` will match `Hans`.
 * At least one of the optional fields must be provided.
-* Only full words will be matched e.g. `Han` will not match `Hans`.
-* Persons matching all the given conditions will be returned (i.e. `AND` search) except for multiple tags and modules.
-* If multiple tags or modules are provided, it will do `OR` search to tags and modules and do `AND` search with rest of the parameters.
+* Only full words will be matched e.g. `Han` will not match `Hans`, same to all parameter except phone number.
+* At least 3 digits of number must be provided to filter phone number and it will return all matching numbers that contains specified number.
+* Persons matching all the given conditions will be returned (i.e. `AND` search).
+
+<div markdown="span" class="alert alert-danger">⚠️ **Warning:**
+Each parameter can only contain one keyword.
+</div>
 
 Examples:
 * `filter n/John` returns `john` and `John Doe` (filter by name)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,9 +131,9 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li` _(search by multiple parameters)_ <br> 
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
-### Filter persons: `filter`
+### Filter persons : `filter`
 
-Filter persons who meet all specified conditions.
+Filters persons who meet all specified conditions.
 
 Format: `filter [n/name] [p/phone] [g/gender] [t/tag]... [m/module]...`
 * The filter is case-insensitive. eg `hans` will match `Hans`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,7 +131,7 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li` _(search by multiple parameters)_ <br> 
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
-### Filter persons
+### Filter persons: `filter`
 
 Filter persons who meet all specified conditions.
 

--- a/src/main/java/seedu/address/model/person/FilterPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterPredicate.java
@@ -89,7 +89,7 @@ public class FilterPredicate implements Predicate<Person> {
     private boolean filterModules(Person person) {
         return filterPersonDescriptor.getModules()
                 .map(modules -> modules.stream()
-                        .anyMatch(module -> person.getModules().stream()
+                        .allMatch(module -> person.getModules().stream()
                                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.module, keyword.module)))
                 )
                 .orElse(true);
@@ -103,7 +103,7 @@ public class FilterPredicate implements Predicate<Person> {
     private boolean filterTags(Person person) {
         return filterPersonDescriptor.getTags()
                 .map(tags -> tags.stream()
-                        .anyMatch(tag -> person.getTags().stream()
+                        .allMatch(tag -> person.getTags().stream()
                                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword.tagName)))
                 )
                 .orElse(true);


### PR DESCRIPTION
- Specify the input requirement for filter in UG.
- Change the implementation of filter tags and module. Now it should do the `AND` operation to all parameter instead of `OR` operation.