### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -178,37 +178,74 @@ Classes used by multiple components are in the `seedu.address.commons` package.
 
 This section describes some noteworthy details on how certain features are implemented.
 
-### \[Proposed\] Undo/redo feature
+### Undo/redo feature
 
-#### Proposed Implementation
+#### Implementation Overview
 
-The proposed undo/redo mechanism is facilitated by `VersionedAddressBook`. It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`. Additionally, it implements the following operations:
+The undo/redo functionality is implemented in the `VersionedAddressBook`, which extends the basic `AddressBook` to include versioning capabilities. This is achieved by maintaining an internal history of address book states. The history is stored in a list (`addressBookStateList`), and the current state is tracked by the `currentStatePointer`.
 
-* `VersionedAddressBook#commit()` — Saves the current address book state in its history.
-* `VersionedAddressBook#undo()` — Restores the previous address book state from its history.
-* `VersionedAddressBook#redo()` — Restores a previously undone address book state from its history.
+The key operations involved in undo/redo are:
 
-These operations are exposed in the `Model` interface as `Model#commitAddressBook()`, `Model#undoAddressBook()` and `Model#redoAddressBook()` respectively.
+- **`VersionedAddressBook#save()`**: Saves the current state of the address book into the history list.
+- **`VersionedAddressBook#undo()`**: Restores the address book to the previous state.
+- **`VersionedAddressBook#redo()`**: Restores the address book to a previously undone state.
 
-Given below is an example usage scenario and how the undo/redo mechanism behaves at each step.
+These operations are available to the rest of the system through the `Model` interface, specifically:
 
-Step 1. The user launches the application for the first time. The `VersionedAddressBook` will be initialized with the initial address book state, and the `currentStatePointer` pointing to that single address book state.
+- `Model#saveAddressBook()`
+- `Model#undoAddressBook()`
+- `Model#redoAddressBook()`
+
+---
+
+## How Undo/Redo Works
+
+The mechanism functions as follows:
+
+1. **Save**: Every modification to the address book, such as `add`, `delete`, or `edit` commands, triggers a save operation to save the current state of the address book.
+
+2. **Undo**: The undo operation moves the `currentStatePointer` backward and restores the previous state. If no more undo operations can be performed (i.e., if the pointer is at the start of the history), the operation fails and returns an error.
+
+3. **Redo**: The redo operation moves the `currentStatePointer` forward and restores the next state that was undone. If there are no undone states, the operation fails and returns an error.
+
+---
+
+### Example Flow
+
+Here is how undo and redo would work through a sequence of user actions:
+
+---
+
+#### Step 1. Initial State
+Upon launching the application, the `VersionedAddressBook` is initialized with the default state (an empty address book, for example). This state is stored in the `addressBookStateList` as the first entry, and the `currentStatePointer` points to this state.
 
 ![UndoRedoState0](images/UndoRedoState0.png)
 
-Step 2. The user executes `delete 5` command to delete the 5th person in the address book. The `delete` command calls `Model#commitAddressBook()`, causing the modified state of the address book after the `delete 5` command executes to be saved in the `addressBookStateList`, and the `currentStatePointer` is shifted to the newly inserted address book state.
+---
+
+#### Step 2. Performing a Deletion
+When a user executes the `delete` command (e.g., `delete 5`), the current state of the address book is saved before the change is made. This ensures that the delete action is reversible. The new state of the address book (with the 5th person deleted) is then stored in the history.
+
+The `saveAddressBook()` operation is called internally, and the `currentStatePointer` is moved forward to point to the newly saved state.
 
 ![UndoRedoState1](images/UndoRedoState1.png)
 
-Step 3. The user executes `add n/David …​` to add a new person. The `add` command also calls `Model#commitAddressBook()`, causing another modified address book state to be saved into the `addressBookStateList`.
+---
+
+#### Step 3. Performing an Addition
+Next, if a user executes an `add` command (e.g., `add n/David ...`), a new state of the address book is created. As before, `saveAddressBook()` is invoked to save the new state, and the `currentStatePointer` is shifted to this new state.
 
 ![UndoRedoState2](images/UndoRedoState2.png)
 
-<div markdown="span" class="alert alert-info">:information_source: **Note:** If a command fails its execution, it will not call `Model#commitAddressBook()`, so the address book state will not be saved into the `addressBookStateList`.
+<div markdown="span" class="alert alert-info">:information_source: **Note:** If a command fails its execution, it will not call `Model#saveAddressBook()`, so the address book state will not be saved into the `addressBookStateList`.
 
 </div>
+---
 
-Step 4. The user now decides that adding the person was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous address book state, and restores the address book to that state.
+#### Step 4. Undoing the Addition
+If the user decides to undo the most recent action (the `add` command), the `undo` operation will restore the address book to the state before the addition. Internally, `undoAddressBook()` is called, which moves the `currentStatePointer` backward and restores the state.
+
+If the pointer is already at the first state (the initial state), attempting to undo will return an error.
 
 ![UndoRedoState3](images/UndoRedoState3.png)
 
@@ -217,7 +254,10 @@ than attempting to perform the undo.
 
 </div>
 
-The following sequence diagram shows how an undo operation goes through the `Logic` component:
+#### Undo Sequence Diagram
+The following sequence diagram shows how the undo operation works across the `Logic` and `Model` components:
+
+`Logic`:
 
 ![UndoSequenceDiagram](images/UndoSequenceDiagram-Logic.png)
 
@@ -225,7 +265,7 @@ The following sequence diagram shows how an undo operation goes through the `Log
 
 </div>
 
-Similarly, how an undo operation goes through the `Model` component is shown below:
+`Model`:
 
 ![UndoSequenceDiagram](images/UndoSequenceDiagram-Model.png)
 
@@ -235,32 +275,44 @@ The `redo` command does the opposite — it calls `Model#redoAddressBook()`,
 
 </div>
 
-Step 5. The user then decides to execute the command `list`. Commands that do not modify the address book, such as `list`, will usually not call `Model#commitAddressBook()`, `Model#undoAddressBook()` or `Model#redoAddressBook()`. Thus, the `addressBookStateList` remains unchanged.
+---
+
+#### Step 5. Redoing the Addition
+If the user decides to redo the action after undoing it, the `redo` operation will restore the state that was undone. The `redoAddressBook()` method is invoked, which moves the `currentStatePointer` forward to the next state in history and restores that state.
+
+As with undo, if the pointer is at the last state in the list, trying to redo will return an error.
 
 ![UndoRedoState4](images/UndoRedoState4.png)
 
-Step 6. The user executes `clear`, which calls `Model#commitAddressBook()`. Since the `currentStatePointer` is not pointing at the end of the `addressBookStateList`, all address book states after the `currentStatePointer` will be purged. Reason: It no longer makes sense to redo the `add n/David …​` command. This is the behavior that most modern desktop applications follow.
+#### Redo Sequence Diagram
+The following sequence diagram shows how the redo operation works across the `Logic` and `Model` components:
 
 ![UndoRedoState5](images/UndoRedoState5.png)
+
+---
 
 The following activity diagram summarizes what happens when a user executes a new command:
 
 <img src="images/CommitActivityDiagram.png" width="250" />
 
-#### Design considerations:
 
-**Aspect: How undo & redo executes:**
+---
 
-* **Alternative 1 (current choice):** Saves the entire address book.
-  * Pros: Easy to implement.
-  * Cons: May have performance issues in terms of memory usage.
+## Design Considerations
 
-* **Alternative 2:** Individual command knows how to undo/redo by
-  itself.
-  * Pros: Will use less memory (e.g. for `delete`, just save the person being deleted).
-  * Cons: We must ensure that the implementation of each individual command are correct.
+Here are the important aspects of the undo/redo implementation:
 
-_{more aspects and alternatives to be added}_
+- **Saving Mechanism:** Each modification to the address book (like `add`, `delete`, or `edit`) triggers a call to `saveAddressBook()`. This function stores the current state of the address book and updates the `currentStatePointer`. However, commands that do not modify the address book (such as `list`, `find`, or `filter`) do not trigger a call to `saveAddressBook()`, and therefore do not modify the history.
+
+- **Undo/Redo Pointer Management:** The `currentStatePointer` is moved backward during undo and forward during redo. If no more states can be undone or redone, appropriate error messages are returned.
+
+- **Memory Considerations:** Since each address book state is stored in memory, excessive changes could increase memory usage. The current implementation keeps track of all states but might need optimization in the future, depending on the application’s use case.
+
+- **State Purging:** After calling `undo`, when a command that modifies the address book is executed (such as `add`, `delete`, or `edit`), the states after the current one are purged to ensure consistency. This prevents errors from conflicting history states. Additionally, after calls to `archive` and `load`, the history is also purged to ensure consistency between different data files.
+
+---
+
+
 
 ### \[Proposed\] Data archiving
 
@@ -294,7 +346,7 @@ The following sequence diagram illustrate how an archive operation is processed 
 
 **Scenario 3 Loading from a file**
 
-In this scenario, the user is trying to load the an address book from a file named `archiveFile1.json`. He enters the command `load pa/archiveFile1.json`. The data in the current working address book will be discarded. The data in `archiveFile1.json` will be loaded into the working address book.
+In this scenario, the user is trying to load the address book from a file named `archiveFile1.json`. He enters the command `load pa/archiveFile1.json`. The data in the current working address book will be discarded. The data in `archiveFile1.json` will be loaded into the working address book.
 ![Load](images/Load.png)
 
 The following sequence diagram illustrate how an archive operation is processed under `Logic` component.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -240,6 +240,7 @@ Next, if a user executes an `add` command (e.g., `add n/David ...`), a new state
 <div markdown="span" class="alert alert-info">:information_source: **Note:** If a command fails its execution, it will not call `Model#saveAddressBook()`, so the address book state will not be saved into the `addressBookStateList`.
 
 </div>
+
 ---
 
 #### Step 4. Undoing the Addition

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -139,7 +139,8 @@ Examples:
 * `find John` returns `john` and `John Doe` _(search by name)_
 * `find colleague` returns `Bernice Yu` and `Roy Balakrishnan` _(search by tag)_
 * `find alex david` returns `Alex Yeoh`, `David Li` _(search by multiple parameters)_ <br> 
-  ![result for 'find alex david'](images/findAlexDavidResult.png)
+
+![result for 'find alex david'](images/findAlexDavidResult.png)
 
 ### Filter persons : `filter`
 
@@ -178,11 +179,38 @@ Examples:
 
 ### Undoing the last action: `undo`
 
-Reverts the last action performed in the application, allowing you to recover data that may have been deleted or modified unintentionally.
+The `undo` command allows you to reverse the last action performed, helping you recover any data that may have been unintentionally deleted or modified.
 
-Format: `undo`
+**Format:** `undo`
 
-* **Note:** This command does not work with the `list`, `filter`, or `find` commands.
+#### How it works:
+- When you perform an action that modifies the address book (like adding, editing, or deleting an entry), that action is saved in memory.
+- By executing `undo`, the most recent modification is reverted, and the address book is restored to its previous state.
+
+<div markdown="block" class="alert alert-primary">
+:bulb: **Tips:** for Efficient Usage <br>
+
+1. **Use Undo After a Mistake**: If you accidentally delete or modify a contact, you can quickly use `undo` to revert the last action and restore the previous state. <br>
+2. **Undo Works Only for Modifying Commands**: Only actions that modify the address book (like `add`, `edit`, or `delete`) can be undone. Commands like `list`, `filter`, or `find` do not trigger the undo mechanism.
+</div>
+
+<div markdown="span" class="alert alert-secondary">
+:question: **Common Question:**
+Why does `undo` not work after I run `list`, `filter`, or `find`? <br>
+`undo` only works for actions that modify the address book. Since `list`, `filter`, or `find` do not modify the data, they do not impact the undo history.
+</div>
+
+<div markdown="span" class="alert alert-primary">
+:rotating_light: **Warning:**
+Executing a command that modifies the address book (like `add`, `edit`, or `delete`) will **clear the redo stack**. This means once you undo an action and perform another modification, you cannot redo the previous undone action.
+</div>
+
+#### Example Scenario:
+1. You delete a contact.
+    - *Before Delete:* [Initial State]
+    - *After Delete:* [After Delete Command]
+2. You decide to undo the delete action.
+    - *After Undo:* [After Undo Command] – The deleted contact is restored.
 
 <img src="images/UndoRedoExample1.png" alt="Initial State" width="60%" />
 <img src="images/UndoRedoExample2.png" alt="After Delete Command" width="60%" />
@@ -191,19 +219,44 @@ Format: `undo`
 Examples:
 * `undo` will revert the last command executed, restoring the previous state of the address book.
 
-### Redoing the last undone action: `redo`
+### Redoing the Last Undone Action: `redo`
 
-Restores the last action that was undone, allowing you to recover data after an undo operation.
+The `redo` command allows you to reapply the last action that was undone, restoring the previous state of the address book. This can be useful if you change your mind after undoing an action.
 
-Format: `redo`
+**Format:** `redo`
 
-* **Note:** This command does not work with the `list`, `filter`, or `find` commands.
+- **Note:** Like `undo`, the `redo` command cannot be used with commands like `list`, `filter`, or `find`.
+
+#### How it works:
+- If you’ve used `undo` to reverse an action, the `redo` command will restore that action, essentially “re-doing” it.
+
+<div markdown="block" class="alert alert-primary">
+:bulb: **Tips:** for Efficient Usage <br>
+
+1. **Use Redo to Restore Actions**: If you’ve undone an action by mistake, `redo` lets you reapply the change quickly. It’s useful when you second-guess your decision.
+2. **Redo Works Only After Undo**: `redo` will only work if an action has been undone previously. If you haven’t undone an action, `redo` will not perform anything.
+</div>
+
+<div markdown="span" class="alert alert-secondary">
+:question: **Common Question:**
+Why does `redo` not work after I’ve made new changes to the address book? <br>
+`redo` only works if there is a previous action that was undone. If a new action is performed after an undo, the redo history is cleared, and there is nothing to redo.
+</div>
+
+<div markdown="span" class="alert alert-primary">
+:rotating_light: **Warning:**
+Executing a command that modifies the address book (like `add`, `edit`, or `delete`) will **clear the redo stack**. This means once you undo a change and then modify the address book again, you will lose the ability to redo the previous undone action.
+</div>
+
+#### Example Scenario:
+1. You undo a deletion of a contact.
+    - *After Undo:* [After Undo Command] – The deleted contact is restored.
+2. You decide to redo the action and restore the contact again.
+    - *After Redo:* [After Redo Command] – The contact is deleted once more.
 
 <img src="images/UndoRedoExample4.png" alt="After Redo Command" width="60%" />
 
-Examples:
-* `redo` will reapply the last command that was undone, restoring the previous state of the address book.
-
+---
 
 ### Grading a Module: `grade`
 
@@ -269,6 +322,12 @@ There should be only one file name provided.
 Avoid loading non-address book .json files as it may result in unexpected behaviours
 
 All the entries in the current address book will be discard. So archiving current address book before loading is recommended.
+</div>
+
+<div markdown="span" class="alert alert-secondary">
+:question: **Common Question:**
+What happens to the undo/redo stack after archiving or loading the address book? <br>
+When you call `archive` or `load`, the undo/redo history is cleared to prevent inconsistencies between the address book data and the stored history. Always ensure the current state is saved before performing these actions.
 </div>
 
 ### Clearing all entries : `clear`

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -25,7 +25,7 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_GENDER + "GENDER "
-            + "[" + PREFIX_MODULE + "MODULE]..."
+            + PREFIX_MODULE + "MODULE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -95,7 +95,7 @@ public class ParserUtil {
     public static Module parseModule(String module) throws ParseException {
         requireNonNull(module);
         String trimmedModuleName = module.trim();
-        if (!Module.isValidModule(trimmedModuleName)) {
+        if (!Module.isValidModule(trimmedModuleName) || !Module.isValidLength(trimmedModuleName)) {
             throw new ParseException(Module.MESSAGE_CONSTRAINTS);
         }
         return new Module(trimmedModuleName);

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -8,8 +8,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidModule(String)}
  */
 public class Module {
-    public static final String MESSAGE_CONSTRAINTS = "Modules should consist of alphanumeric characters only,"
-            + "and it should be between 1 and 30 characters.";
+    public static final String MESSAGE_CONSTRAINTS = "Modules should consist of alphanumeric characters and "
+            + "spaces only, and it should be between 1 and 30 characters.";
     public static final String GRADE_CONSTRAINTS = "Grade should be a number between 0 and 100.";
     public static final String VALIDATION_REGEX = "^[\\p{Alnum} ]+$";
 

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -11,7 +11,7 @@ public class Module {
     public static final String MESSAGE_CONSTRAINTS = "Modules should consist of alphanumeric characters only,"
             + "and it should be between 1 and 30 characters.";
     public static final String GRADE_CONSTRAINTS = "Grade should be a number between 0 and 100.";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "^[\\p{Alnum} ]+$";
 
     private static final int MIN_MODULE_LENGTH = 1;
     private static final int MAX_MODULE_LENGTH = 30;
@@ -82,7 +82,7 @@ public class Module {
      * Returns true if a given string is a valid module.
      */
     public static boolean isValidModule(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.trim().matches(VALIDATION_REGEX);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -90,7 +90,7 @@ public class Module {
      * @param test the module value to be tested.
      * @return the result of the test.
      */
-    private boolean isValidLength(String test) {
+    public static boolean isValidLength(String test) {
         boolean isValidMinLength = test.length() >= MIN_MODULE_LENGTH;
         boolean isValidMaxLength = test.length() <= MAX_MODULE_LENGTH;
         return isValidMinLength && isValidMaxLength;

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -36,6 +36,20 @@ public class Module {
     }
 
     /**
+     * Constructs an {@code Module}. Only used in grading.
+     *
+     * @param module a valid Module.
+     */
+    public Module(String module, String grade) {
+        requireNonNull(module);
+        checkArgument(isValidModule(module), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidLength(module), MESSAGE_CONSTRAINTS);
+        this.module = module;
+        this.grade = grade.equals("Ungraded") ? UNGRADED : Integer.parseInt(grade);
+        this.isGraded = this.grade >= 0;
+    }
+
+    /**
      * Constructs an {@code Module} with grade.
      * @param grade a valid grade (0 - 100).
      */

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^(?=.*[\\p{L}\\p{N}])[\\p{L}\\-\\., ]{1,100}$";
+    public static final String VALIDATION_REGEX = "^(?=.*[\\p{L}\\p{N}])[\\p{L}\\-\\., /]{1,100}$";
     private static final int MIN_LENGTH = 1;
     private static final int MAX_LENGTH = 100;
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,30 +7,31 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <HBox>
-      <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" spacing="5">
+      <VBox alignment="CENTER_LEFT" minHeight="105" minWidth="-Infinity" prefWidth="250.0" spacing="5" GridPane.columnIndex="0">
         <padding>
-          <Insets top="5" right="5" bottom="5" left="15" />
+          <Insets bottom="5" left="15" right="5" top="5" />
         </padding>
-        <HBox spacing="0.5" alignment="CENTER_LEFT">
+        <HBox alignment="CENTER_LEFT" spacing="0.5">
           <Label fx:id="id" styleClass="cell_big_label">
             <minWidth>
               <!-- Ensures that the label text is never truncated -->
               <Region fx:constant="USE_PREF_SIZE" />
             </minWidth>
           </Label>
-          <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+          <Label fx:id="name" maxWidth="200" styleClass="cell_big_label" text="\$first" />
+          <Label fx:id="gender" styleClass="cell_big_label" text="\$gender" />
           <minWidth>
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
-          <Label fx:id="gender" text="\$gender" styleClass="cell_big_label" />
         </HBox>
 
         <HBox spacing="5">
@@ -41,10 +42,12 @@
         <FlowPane fx:id="tags" />
       </VBox>
 
-      <HBox spacing="0.5" alignment="CENTER" style="-fx-padding: 30;">
+      <HBox alignment="CENTER" spacing="0.5" style="-fx-padding: 30;">
         <FlowPane fx:id="modules" />
-        <FlowPane fx:id="grades" />
       </HBox>
     </HBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -10,6 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
@@ -83,53 +84,80 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+    public void execute_undoRedoSingleValidIndex_success() throws Exception {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Index lastPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person personToDelete = model.getFilteredPersonList().get(lastPersonIndex.getZeroBased());
+
+        DeleteCommand deleteCommand = new DeleteCommand(lastPersonIndex);
+
+        // Update expected model
         expectedModel.deletePerson(personToDelete);
         expectedModel.saveAddressBook();
-        // 1 - delete first person
-        deleteCommand.execute(model);
 
-        // 2 - undo the command
+        // Execute delete command on test model
+        deleteCommand.execute(model);
+        assertFalse(model.getFilteredPersonList().contains(personToDelete));
+
         expectedModel.undoAddressBook();
         assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+        assertTrue(model.getFilteredPersonList().contains(personToDelete));
 
-        // 3 - redo the command
         expectedModel.redoAddressBook();
         assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
+        assertFalse(model.getFilteredPersonList().contains(personToDelete));
     }
 
     @Test
-    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+    public void execute_undoRedoMultipleValidIndex_success() throws Exception {
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        ArrayList<Person> deletedPersons = new ArrayList<>();
+
+        //Perform multiple deletions, saving deleted persons and updating expected model
+        for (int i = 0; i < 3; i++) {
+            Index lastPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+            Person personToDelete = model.getFilteredPersonList().get(lastPersonIndex.getZeroBased());
+
+            DeleteCommand deleteCommand = new DeleteCommand(lastPersonIndex);
+
+            // Update expected model
+            expectedModel.deletePerson(personToDelete);
+            expectedModel.saveAddressBook();
+
+            // Execute delete command on test model
+            deleteCommand.execute(model);
+
+            // Add deleted person to list and verify they are not in the test model list
+            deletedPersons.add(personToDelete);
+            assertFalse(model.getFilteredPersonList().contains(personToDelete));
+        }
+
+        for (int i = deletedPersons.size() - 1; i >= 0; i--) {
+            Person lastDeletedPerson = deletedPersons.get(i);
+
+            // Undo deletion
+            expectedModel.undoAddressBook();
+            assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+            assertTrue(model.getFilteredPersonList().contains(lastDeletedPerson));
+        }
+
+        for (Person personToRedoDelete : deletedPersons) {
+            // Redo deletion
+            expectedModel.redoAddressBook();
+            assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
+            assertFalse(model.getFilteredPersonList().contains(personToRedoDelete));
+        }
+    }
+
+    @Test
+    public void execute_undoRedoInvalidIndex_failure() {
+        Index invalidIndex = Index.fromOneBased(Integer.MAX_VALUE);
+        DeleteCommand deleteCommand = new DeleteCommand(invalidIndex);
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // no changes made, so undo and redo should fail
         assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_FAILURE);
         assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_FAILURE);
-    }
-
-    @Test
-    public void executeUndoRedo_validIndexFilteredList_samePersonDeleted() throws Exception {
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        showPersonAtIndex(model, INDEX_SECOND_PERSON);
-
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        expectedModel.deletePerson(personToDelete);
-        expectedModel.saveAddressBook();
-
-        deleteCommand.execute(model);
-        expectedModel.undoAddressBook();
-
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
-        assertNotEquals(personToDelete, model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()));
-
-        expectedModel.redoAddressBook();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
@@ -248,5 +248,15 @@ public class GradeCommandTest {
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
         }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            //do nothing, but needed since it is called in the default stub.
+        }
+
+        @Override
+        public void saveAddressBook() {
+            //do nothing, but needed since it is called in the default stub.
+        }
     }
 }


### PR DESCRIPTION
### Bug Fixes
1. Module with invalid length now raises an error properly in the chatbot. 
    - Closes #160 
2. Names now allow the character `/` as per specifications.
    - Closes #156
3. Modules are now made compulsory in the error message of `Add`.
    - Closes #153  
4. `Undo` and `Redo` now work with `Grade` commands.
   - Closes #116
   - Closes #152 

### Other Changes
1. The UG and DG has now been updated with information for Undo and Redo, making it more user-centric and easy to read with proper allocations of information blocks. Necessary information about the implementation has also been included in both the guides.
    - Closes #162 
2. Modules now allow spaces in them.
    - Closes #173
3. Modules now align to the left in the UI.
    - Closes #175