### PR TITLE
Check the length of tag when parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'StoreClass.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'StoreClass.jar'
+    archiveFileName = 'addressbook.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -32,7 +32,7 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
     }
 
     /**
@@ -40,7 +40,7 @@ public class Tag {
      * @param test the tag to be tested.
      * @return the result of the test
      */
-    private boolean isValidLength(String test) {
+    private static boolean isValidLength(String test) {
         return test.length() <= MAX_TAG_LENGTH;
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -27,7 +27,8 @@ public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_MODULE = " ";
-    private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_TAG_1 = "#friend";
+    private static final String INVALID_TAG_2 = "LooooooooooooooooooooooooooooooooooongTag";
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "12345678";
     private static final String VALID_MODULE = "CS2103T";
@@ -158,7 +159,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseTag_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG_1));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG_2));
     }
 
     @Test
@@ -181,7 +183,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseTags_collectionWithInvalidTags_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG_1)));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG_2)));
     }
 
     @Test


### PR DESCRIPTION
This will fix the bug that the app has no reaction and fails silently when the input tag is too long.

Close #246 

This is a bug fix due to the following reasons.

The app crashes and there is no reaction message given when a long tag name is produced.
This is caused by a failure in code as the parser never checks if the tag is valid in length (from 1 to 30) which causes the tag to fail to construct and hence crash without any message given.

This bug is fixed by validating the length of input for tags during parsing and producing a parse exception if it is invalid. 

Result:
A error message saying that the tag input is invalid the sent when long tag names is given